### PR TITLE
[FEAT] Search 화면 액션 일부 변경 및 보관함 삭제 UI 추가

### DIFF
--- a/app/src/main/java/com/cocaine/myply/core/base/BaseDialogFragment.kt
+++ b/app/src/main/java/com/cocaine/myply/core/base/BaseDialogFragment.kt
@@ -1,0 +1,32 @@
+package com.cocaine.myply.core.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.DialogFragment
+
+abstract class BaseDialogFragment<T : ViewDataBinding>(private val resId: Int) : DialogFragment() {
+    var binding: T? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        super.onCreateView(inflater, container, savedInstanceState)
+        binding = DataBindingUtil.inflate(inflater, resId, container, false)
+        binding?.lifecycleOwner = viewLifecycleOwner
+
+        return binding?.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setup()
+    }
+
+    abstract fun setup()
+}

--- a/app/src/main/java/com/cocaine/myply/feature/data/datasource/remote/MyPlyService.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/data/datasource/remote/MyPlyService.kt
@@ -1,20 +1,7 @@
 package com.cocaine.myply.feature.data.datasource.remote
 
-import com.cocaine.myply.feature.data.model.MemoInfo
-import com.cocaine.myply.feature.data.model.MemoResponse
-import com.cocaine.myply.feature.data.model.MemoUpdate
-import com.cocaine.myply.feature.data.model.SearchResponse
-import com.cocaine.myply.feature.data.model.SearchTagResponse
-import com.cocaine.myply.feature.data.model.TagResponse
-import com.cocaine.myply.feature.data.model.UserInfoResponse
-import com.cocaine.myply.feature.data.model.UserKeywordUpdateData
-import com.cocaine.myply.feature.data.model.UserMemoList
-import com.cocaine.myply.feature.data.model.UserNameUpdateData
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.PATCH
-import retrofit2.http.Path
-import retrofit2.http.Query
+import com.cocaine.myply.feature.data.model.*
+import retrofit2.http.*
 
 interface MyPlyService {
     @GET("tags/recommend")
@@ -43,4 +30,7 @@ interface MyPlyService {
 
     @GET("tags/recommend")
     suspend fun getRecommendTags(): TagResponse
+
+    @POST("memos/")
+    suspend fun addMemo(@Body body: MemoRequest): MemoResponse
 }

--- a/app/src/main/java/com/cocaine/myply/feature/data/model/KeepModel.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/data/model/KeepModel.kt
@@ -12,10 +12,12 @@ data class MemoResponse(val code: Int, val data: MemoInfo)
 @Parcelize
 data class MemoInfo(
     val memoID: String,
-    val thumbnailURL: String,
+    val thumbnailURL: String?,
     val title: String,
-    val keywords: List<String>,
+    val keywords: List<String>?,
     val body: String
 ) : Parcelable
 
 data class MemoUpdate(val body: String)
+
+data class MemoRequest(val youtubeVideoID: String, val body: String)

--- a/app/src/main/java/com/cocaine/myply/feature/data/repository/MyPlyRepository.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/data/repository/MyPlyRepository.kt
@@ -1,12 +1,7 @@
 package com.cocaine.myply.feature.data.repository
 
 import com.cocaine.myply.feature.data.datasource.remote.MyPlyService
-import com.cocaine.myply.feature.data.model.MemoInfo
-import com.cocaine.myply.feature.data.model.MemoResponse
-import com.cocaine.myply.feature.data.model.MemoUpdate
-import com.cocaine.myply.feature.data.model.UserMemoList
-import com.cocaine.myply.feature.data.model.UserKeywordUpdateData
-import com.cocaine.myply.feature.data.model.UserNameUpdateData
+import com.cocaine.myply.feature.data.model.*
 import javax.inject.Inject
 
 class MyPlyRepository @Inject constructor(private val myPlyService: MyPlyService) {
@@ -29,4 +24,6 @@ class MyPlyRepository @Inject constructor(private val myPlyService: MyPlyService
         myPlyService.updateUserKeyword(userKeywordUpdateData)
 
     suspend fun getRecommendTags() = myPlyService.getRecommendTags()
+
+    suspend fun addMemo(youtubeId: String, body: String = "") = myPlyService.addMemo(MemoRequest(youtubeId, body))
 }

--- a/app/src/main/java/com/cocaine/myply/feature/ui/dialog/MyPlyTwoButtonDialog.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/dialog/MyPlyTwoButtonDialog.kt
@@ -1,0 +1,45 @@
+package com.cocaine.myply.feature.ui.dialog
+
+import android.view.View
+import com.cocaine.myply.R
+import com.cocaine.myply.core.base.BaseDialogFragment
+import com.cocaine.myply.databinding.DialogTwoButtonBinding
+
+class MyPlyTwoButtonDialog :
+    BaseDialogFragment<DialogTwoButtonBinding>(R.layout.dialog_two_button) {
+    companion object {
+        lateinit var title: String
+        lateinit var subTitle: String
+        lateinit var positiveName: String
+        lateinit var negativeName: String
+        lateinit var positiveAction: View.OnClickListener
+        lateinit var negativeAction: View.OnClickListener
+
+        fun setDialogContent(
+            title: String="",
+            subTitle: String="",
+            positiveName: String="",
+            negativeName: String="",
+            positiveAction: View.OnClickListener,
+            negativeAction: View.OnClickListener
+        ) {
+            this.title = title
+            this.subTitle = subTitle
+            this.positiveName = positiveName
+            this.negativeName = negativeName
+            this.positiveAction = positiveAction
+            this.negativeAction = negativeAction
+        }
+    }
+
+    override fun setup() {
+        binding?.apply {
+            dialogTitle.text = title
+            dialogSubtitle.text = subTitle
+            dialogPositive.text = positiveName
+            dialogNegative.text = negativeName
+            dialogPositive.setOnClickListener(positiveAction)
+            dialogNegative.setOnClickListener(negativeAction)
+        }
+    }
+}

--- a/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepAdapter.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepAdapter.kt
@@ -1,5 +1,6 @@
 package com.cocaine.myply.feature.ui.keep
 
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
@@ -7,9 +8,12 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.cocaine.myply.R
+import com.cocaine.myply.core.extension.setBackgroundTint
 import com.cocaine.myply.databinding.ItemKeepBinding
 import com.cocaine.myply.feature.data.model.MemoInfo
 import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipDrawable
+import com.google.android.material.resources.TextAppearance
 
 class KeepAdapter(private val moveToDetail: (Int) -> Unit, private val deleteMemo: (Int) -> Unit) :
     ListAdapter<MemoInfo, KeepAdapter.KeepViewHolder>(diffUtil) {
@@ -44,10 +48,22 @@ class KeepAdapter(private val moveToDetail: (Int) -> Unit, private val deleteMem
         fun bind(memo: MemoInfo) {
             binding.memo = memo
 
-            for (i in memo.keywords) {
+            val chipDrawable = ChipDrawable.createFromAttributes(
+                binding.root.context,
+                null,
+                0,
+                R.style.MyPly_Chip_Keep
+            )
+            memo.keywords?.forEach { keyword ->
                 Chip(binding.root.context).apply {
-                    text = i
+                    text = keyword
+                    setTextColor(Color.WHITE)
+                    setTextAppearance(R.style.Body2_Bold)
+                    setChipDrawable(chipDrawable)
+
                     isCheckable = false
+                    isClickable = false
+
                     binding.keepTags.addView(this)
                 }
             }

--- a/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepAdapter.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepAdapter.kt
@@ -1,6 +1,5 @@
 package com.cocaine.myply.feature.ui.keep
 
-import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
@@ -8,12 +7,8 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.cocaine.myply.R
-import com.cocaine.myply.core.extension.setBackgroundTint
 import com.cocaine.myply.databinding.ItemKeepBinding
 import com.cocaine.myply.feature.data.model.MemoInfo
-import com.google.android.material.chip.Chip
-import com.google.android.material.chip.ChipDrawable
-import com.google.android.material.resources.TextAppearance
 
 class KeepAdapter(private val moveToDetail: (Int) -> Unit, private val deleteMemo: (Int) -> Unit) :
     ListAdapter<MemoInfo, KeepAdapter.KeepViewHolder>(diffUtil) {
@@ -35,6 +30,7 @@ class KeepAdapter(private val moveToDetail: (Int) -> Unit, private val deleteMem
         private val moveToDetail: (Int) -> Unit,
         private val deleteMemo: (Int) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
+        private val tagAdapter = KeepTagAdapter()
         init {
             binding.keepEditBtn.setOnClickListener {
                 moveToDetail(adapterPosition)
@@ -47,25 +43,9 @@ class KeepAdapter(private val moveToDetail: (Int) -> Unit, private val deleteMem
 
         fun bind(memo: MemoInfo) {
             binding.memo = memo
-
-            val chipDrawable = ChipDrawable.createFromAttributes(
-                binding.root.context,
-                null,
-                0,
-                R.style.MyPly_Chip_Keep
-            )
-            memo.keywords?.forEach { keyword ->
-                Chip(binding.root.context).apply {
-                    text = keyword
-                    setTextColor(Color.WHITE)
-                    setTextAppearance(R.style.Body2_Bold)
-                    setChipDrawable(chipDrawable)
-
-                    isCheckable = false
-                    isClickable = false
-
-                    binding.keepTags.addView(this)
-                }
+            memo.keywords?.let { tags ->
+                binding.keepTags.adapter = tagAdapter
+                tagAdapter.submitList(tags)
             }
         }
     }

--- a/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepDetailAdapter.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepDetailAdapter.kt
@@ -1,0 +1,41 @@
+package com.cocaine.myply.feature.ui.keep
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.cocaine.myply.R
+import com.cocaine.myply.databinding.ItemMypageKeywordBinding
+
+class KeepDetailAdapter: ListAdapter<String, KeepDetailAdapter.KeepDetailViewHolder>(diffUtil) {
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<String>() {
+            override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+                return oldItem === newItem
+            }
+
+            override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+                return oldItem == newItem
+            }
+
+        }
+    }
+
+    class KeepDetailViewHolder(private val binding: ItemMypageKeywordBinding): RecyclerView.ViewHolder(binding.root) {
+        fun bind(tag: String) {
+            binding.keyword = tag
+            binding.keywordView.setBackgroundColor(binding.root.resources.getColor(R.color.secondary_brown, null))
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): KeepDetailViewHolder {
+        val binding = DataBindingUtil.inflate<ItemMypageKeywordBinding>(LayoutInflater.from(parent.context), R.layout.item_mypage_keyword, parent,false)
+        return KeepDetailViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: KeepDetailViewHolder, position: Int) {
+        holder.bind(currentList[position])
+    }
+}

--- a/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepDetailFragment.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepDetailFragment.kt
@@ -1,6 +1,5 @@
 package com.cocaine.myply.feature.ui.keep
 
-import android.graphics.Color
 import androidx.core.os.bundleOf
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
@@ -15,8 +14,6 @@ import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
-import com.google.android.material.chip.Chip
-import com.google.android.material.chip.ChipDrawable
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -40,7 +37,7 @@ class KeepDetailFragment: BaseFragment<FragmentKeepDetailBinding>(R.layout.fragm
     }
 
     private fun setMemoDetail() {
-        val adapter = KeepDetailAdapter()
+        val adapter = KeepTagAdapter()
         binding?.keepDetailPlaylist?.playlistTags?.layoutManager = FlexboxLayoutManager(requireContext()).apply{
             flexWrap = FlexWrap.WRAP
             flexDirection = FlexDirection.ROW

--- a/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepDetailFragment.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepDetailFragment.kt
@@ -17,7 +17,7 @@ import com.google.android.flexbox.JustifyContent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class KeepDetailFragment: BaseFragment<FragmentKeepDetailBinding>(R.layout.fragment_keep_detail) {
+class KeepDetailFragment : BaseFragment<FragmentKeepDetailBinding>(R.layout.fragment_keep_detail) {
     private val viewModel: KeepDetailViewModel by viewModels()
 
     override fun setup() {
@@ -38,23 +38,24 @@ class KeepDetailFragment: BaseFragment<FragmentKeepDetailBinding>(R.layout.fragm
 
     private fun setMemoDetail() {
         val adapter = KeepTagAdapter()
-        binding?.keepDetailPlaylist?.playlistTags?.layoutManager = FlexboxLayoutManager(requireContext()).apply{
-            flexWrap = FlexWrap.WRAP
-            flexDirection = FlexDirection.ROW
-            justifyContent = JustifyContent.FLEX_START
-        }
+        binding?.keepDetailPlaylist?.playlistTags?.layoutManager =
+            FlexboxLayoutManager(requireContext()).apply {
+                flexWrap = FlexWrap.WRAP
+                flexDirection = FlexDirection.ROW
+                justifyContent = JustifyContent.FLEX_START
+            }
         val data = arguments?.getParcelable<MemoInfo>(MEMO_KEY)
 
         binding?.keepDetailPlaylist?.playlistTags?.adapter = adapter
         data?.let {
             viewModel.updateMemoData(it)
-            it.keywords?.let { tags -> adapter.submitList(tags)}
+            it.keywords?.let { tags -> adapter.submitList(tags) }
         }
     }
 
     fun moveToKeepWrite() {
         val controller = findNavController()
-        if(controller.currentDestination?.id == R.id.keepDetailFragment) {
+        if (controller.currentDestination?.id == R.id.keepDetailFragment) {
             val memoData = bundleOf(MEMO_KEY to viewModel.memoDetail.value)
             controller.navigate(R.id.action_keepDetailFragment_to_keepWriteFragment, memoData)
         }
@@ -63,21 +64,27 @@ class KeepDetailFragment: BaseFragment<FragmentKeepDetailBinding>(R.layout.fragm
     fun moveToKeepShare() {
         val controller = findNavController()
 
-        if(controller.currentDestination?.id == R.id.keepDetailFragment) {
+        if (controller.currentDestination?.id == R.id.keepDetailFragment) {
             val memoData = bundleOf(MEMO_KEY to viewModel.memoDetail.value)
             controller.navigate(R.id.action_keepDetailFragment_to_keepShareFragment, memoData)
         }
     }
 
     private fun showDeleteMemoDialog() {
-        MyPlyTwoButtonDialog.setDialogContent("", "", "삭제", "취소", {}, {})
-        findNavController().navigate(R.id.action_keepDetailFragment_to_myPlyTwoButtonDialog)
+        MyPlyTwoButtonDialog.setDialogContent(
+            requireContext().getString(R.string.keep_delete_title),
+            requireContext().getString(R.string.keep_delete_body),
+            requireContext().getString(R.string.keep_delete_pos),
+            requireContext().getString(R.string.keep_delete_neg),
+            {},
+            { findNavController().popBackStack() })
+        findNavController().navigate(R.id.myPlyTwoButtonDialog)
     }
 
     fun deleteMemo() {
         android.util.Log.e("clicked", "heart")
         viewModel.memoDetail.value?.body?.let {
-            if(it.length > 0) {
+            if (it.length > 0) {
                 showDeleteMemoDialog()
             }
         }

--- a/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepDetailFragment.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepDetailFragment.kt
@@ -1,5 +1,6 @@
 package com.cocaine.myply.feature.ui.keep
 
+import android.graphics.Color
 import androidx.core.os.bundleOf
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
@@ -8,8 +9,14 @@ import com.cocaine.myply.R
 import com.cocaine.myply.core.base.BaseFragment
 import com.cocaine.myply.databinding.FragmentKeepDetailBinding
 import com.cocaine.myply.feature.data.model.MemoInfo
+import com.cocaine.myply.feature.ui.dialog.MyPlyTwoButtonDialog
 import com.cocaine.myply.feature.ui.keep.KeepFragment.Companion.MEMO_KEY
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.flexbox.JustifyContent
 import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipDrawable
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -33,16 +40,18 @@ class KeepDetailFragment: BaseFragment<FragmentKeepDetailBinding>(R.layout.fragm
     }
 
     private fun setMemoDetail() {
+        val adapter = KeepDetailAdapter()
+        binding?.keepDetailPlaylist?.playlistTags?.layoutManager = FlexboxLayoutManager(requireContext()).apply{
+            flexWrap = FlexWrap.WRAP
+            flexDirection = FlexDirection.ROW
+            justifyContent = JustifyContent.FLEX_START
+        }
         val data = arguments?.getParcelable<MemoInfo>(MEMO_KEY)
+
+        binding?.keepDetailPlaylist?.playlistTags?.adapter = adapter
         data?.let {
             viewModel.updateMemoData(it)
-
-            for(i in it.keywords) {
-                Chip(requireContext()).apply {
-                    text = i
-                    binding?.keepDetailPlaylist?.playlistTags?.addView(this)
-                }
-            }
+            it.keywords?.let { tags -> adapter.submitList(tags)}
         }
     }
 
@@ -60,6 +69,20 @@ class KeepDetailFragment: BaseFragment<FragmentKeepDetailBinding>(R.layout.fragm
         if(controller.currentDestination?.id == R.id.keepDetailFragment) {
             val memoData = bundleOf(MEMO_KEY to viewModel.memoDetail.value)
             controller.navigate(R.id.action_keepDetailFragment_to_keepShareFragment, memoData)
+        }
+    }
+
+    private fun showDeleteMemoDialog() {
+        MyPlyTwoButtonDialog.setDialogContent("", "", "삭제", "취소", {}, {})
+        findNavController().navigate(R.id.action_keepDetailFragment_to_myPlyTwoButtonDialog)
+    }
+
+    fun deleteMemo() {
+        android.util.Log.e("clicked", "heart")
+        viewModel.memoDetail.value?.body?.let {
+            if(it.length > 0) {
+                showDeleteMemoDialog()
+            }
         }
     }
 }

--- a/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepFragment.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepFragment.kt
@@ -1,11 +1,13 @@
 package com.cocaine.myply.feature.ui.keep
 
+import android.widget.Toast
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.cocaine.myply.R
 import com.cocaine.myply.core.base.BaseFragment
 import com.cocaine.myply.databinding.FragmentKeepBinding
+import com.cocaine.myply.feature.ui.dialog.MyPlyTwoButtonDialog
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -31,13 +33,28 @@ class KeepFragment : BaseFragment<FragmentKeepBinding>(R.layout.fragment_keep) {
     }
 
     private fun setRecyclerView() {
-        adapter = KeepAdapter ({ position ->
+        adapter = KeepAdapter({ position ->
             val navController = findNavController()
-            if(navController.currentDestination?.id == R.id.keepFragment) {
+            if (navController.currentDestination?.id == R.id.keepFragment) {
                 val bundle = bundleOf(MEMO_KEY to adapter.currentList[position])
                 navController.navigate(R.id.action_keepFragment_to_keepDetailFragment, bundle)
             }
         }, { position ->
+            val data = adapter.currentList[position]
+            android.util.Log.e("delete data", "$data")
+
+            val navController = findNavController()
+            if (data.body.length > 0 && navController.currentDestination?.id == R.id.keepFragment) {
+                MyPlyTwoButtonDialog.setDialogContent(requireContext().getString(R.string.keep_delete_title),
+                    requireContext().getString(R.string.keep_delete_body),
+                    requireContext().getString(R.string.keep_delete_pos),
+                    requireContext().getString(R.string.keep_delete_neg), {
+
+                    }, { navController.popBackStack() })
+                findNavController().navigate(R.id.myPlyTwoButtonDialog)
+            } else {
+                Toast.makeText(requireContext(), "delete memo", Toast.LENGTH_SHORT).show()
+            }
 
         })
 

--- a/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepTagAdapter.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepTagAdapter.kt
@@ -1,0 +1,41 @@
+package com.cocaine.myply.feature.ui.keep
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.cocaine.myply.R
+import com.cocaine.myply.databinding.ItemMypageKeywordBinding
+
+class KeepTagAdapter: ListAdapter<String, KeepTagAdapter.KeepDetailViewHolder>(diffUtil) {
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<String>() {
+            override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+                return oldItem === newItem
+            }
+
+            override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+                return oldItem == newItem
+            }
+
+        }
+    }
+
+    class KeepDetailViewHolder(private val binding: ItemMypageKeywordBinding): RecyclerView.ViewHolder(binding.root) {
+        fun bind(tag: String) {
+            binding.keyword = tag
+            binding.keywordView.setBackgroundColor(binding.root.resources.getColor(R.color.secondary_brown, null))
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): KeepDetailViewHolder {
+        val binding = DataBindingUtil.inflate<ItemMypageKeywordBinding>(LayoutInflater.from(parent.context), R.layout.item_mypage_keyword, parent,false)
+        return KeepDetailViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: KeepDetailViewHolder, position: Int) {
+        holder.bind(currentList[position])
+    }
+}

--- a/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepViewModel.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/keep/KeepViewModel.kt
@@ -15,10 +15,6 @@ class KeepViewModel @Inject constructor(private val usecase: KeepUsecase) : Base
     private val _userMemoList = MutableLiveData<List<MemoInfo>>()
     val userMemoList: LiveData<List<MemoInfo>> = _userMemoList
 
-    init {
-        getKeepUserMemoList()
-    }
-
     fun getKeepUserMemoList() {
         viewModelScope.launch(Dispatchers.IO + coroutineExceptionHandler) {
             val result = usecase.getUserMemoList()

--- a/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchAdapter.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchAdapter.kt
@@ -1,21 +1,18 @@
 package com.cocaine.myply.feature.ui.search
 
 import android.content.Intent
-import android.graphics.Color
 import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.util.rangeTo
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.cocaine.myply.R
 import com.cocaine.myply.databinding.ItemPlaylistBinding
-import com.cocaine.myply.feature.data.model.ChipStyles
 import com.cocaine.myply.feature.data.model.MemoState
 import com.cocaine.myply.feature.data.model.MusicResponse
-import com.google.android.material.chip.Chip
-import com.google.android.material.chip.ChipDrawable
 
 class SearchAdapter(private val getYoutubeId: (Int, String) -> Unit) :
     ListAdapter<MusicResponse, SearchAdapter.SearchViewHolder>(diffUtil) {
@@ -40,28 +37,13 @@ class SearchAdapter(private val getYoutubeId: (Int, String) -> Unit) :
         private val getYoutubeId: (Int, String) -> Unit
     ) :
         RecyclerView.ViewHolder(binding.root) {
+        private val adapter = SearchTagAdapter()
         fun bind(data: MusicResponse) {
             binding.video = data
-            val chipStyles = ChipStyles.values()
-            data.youtubeTags?.forEachIndexed { i, tag ->
-                val chipDrawable = ChipDrawable.createFromAttributes(
-                    binding.root.context,
-                    null,
-                    0,
-                    chipStyles[i % chipStyles.size].id
-                )
-                Chip(binding.root.context).apply {
-                    text = tag
-                    isCheckable = false
-                    isClickable = false
 
-                    setTextColor(Color.WHITE)
-                    setTextAppearance(R.style.Body2_Semibold)
-
-                    setChipDrawable(chipDrawable)
-
-                    binding.playlistTags.addView(this)
-                }
+            binding.playlistTags.adapter = adapter
+            data.youtubeTags?.let {
+                adapter.submitList(it)
             }
 
             binding.playlistHeart.setOnClickListener {

--- a/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchAdapter.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchAdapter.kt
@@ -1,6 +1,8 @@
 package com.cocaine.myply.feature.ui.search
 
+import android.content.Intent
 import android.graphics.Color
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
@@ -15,7 +17,8 @@ import com.cocaine.myply.feature.data.model.MusicResponse
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipDrawable
 
-class SearchAdapter(private val getYoutubeId: (Int, String) -> Unit) : ListAdapter<MusicResponse, SearchAdapter.SearchViewHolder>(diffUtil) {
+class SearchAdapter(private val getYoutubeId: (Int, String) -> Unit) :
+    ListAdapter<MusicResponse, SearchAdapter.SearchViewHolder>(diffUtil) {
     companion object {
         val diffUtil = object : DiffUtil.ItemCallback<MusicResponse>() {
             override fun areItemsTheSame(oldItem: MusicResponse, newItem: MusicResponse): Boolean {
@@ -32,7 +35,10 @@ class SearchAdapter(private val getYoutubeId: (Int, String) -> Unit) : ListAdapt
         }
     }
 
-    class SearchViewHolder(private val binding: ItemPlaylistBinding, private val getYoutubeId: (Int, String) -> Unit) :
+    class SearchViewHolder(
+        private val binding: ItemPlaylistBinding,
+        private val getYoutubeId: (Int, String) -> Unit
+    ) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(data: MusicResponse) {
             binding.video = data
@@ -59,9 +65,17 @@ class SearchAdapter(private val getYoutubeId: (Int, String) -> Unit) : ListAdapt
             }
 
             binding.playlistHeart.setOnClickListener {
-                binding.video = data.copy(memoState = MemoState.LIKED)
-                android.util.Log.e("video", "${binding.video.toString()}")
+                binding.video = data.copy(memoState = MemoState.FILLED)
                 getYoutubeId(adapterPosition, data.youtubeVideoID)
+            }
+
+            binding.playlistPlayBtn.setOnClickListener {
+                kotlin.runCatching {
+                    binding.root.context.startActivity(
+                        Intent(Intent.ACTION_VIEW).setData(Uri.parse(data.videoDeepLink))
+                            .setPackage("com.google.android.youtube")
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchFragment.kt
@@ -1,6 +1,9 @@
 package com.cocaine.myply.feature.ui.search
 
+import android.content.Context
+import android.view.KeyEvent
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -27,6 +30,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
         setSearchButtonVisible()
         setViewModel()
         handleError()
+        searchPlayListWithKeyboardEnter()
     }
 
     private fun setRecyclerview() {
@@ -125,5 +129,25 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
 
         binding?.searchShimmer?.visibility = View.VISIBLE
         viewModel.searchMusicPlayList(query)
+        hideSoftKeyboard()
+    }
+    
+    private fun searchPlayListWithKeyboardEnter() {
+        binding?.searchEditTxt?.setOnKeyListener { view, i, keyEvent ->
+            when(keyEvent.keyCode) {
+                KeyEvent.KEYCODE_ENTER -> {
+                    searchPlayList(viewModel.curSearchMsg.value)
+                }
+            }
+
+            return@setOnKeyListener true
+        }
+    }
+
+    private fun hideSoftKeyboard() {
+        val view = requireView()
+        val imm = requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
     }
 }

--- a/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchFragment.kt
@@ -12,7 +12,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.cocaine.myply.R
 import com.cocaine.myply.core.base.BaseFragment
 import com.cocaine.myply.databinding.FragmentSearchBinding
-import com.cocaine.myply.feature.data.model.ChipStyles
 import com.cocaine.myply.feature.data.model.MusicResponse
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipDrawable
@@ -73,9 +72,12 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
             val size = recommend.size - 1
             val randomNumbers = List(6) { Random.nextInt(0, size) }
 
-            val chipStyles = ChipStyles.values()
+            val chipStyles = listOf(
+                R.style.MyPly_Chip_Red, R.style.MyPly_Chip_green, R.style.MyPly_Chip_yellow, R.style.MyPly_Chip_Blue
+            )
+
             for (i in randomNumbers) {
-                val chipDrawable = ChipDrawable.createFromAttributes(requireContext(), null, 0, chipStyles[i % chipStyles.size].id)
+                val chipDrawable = ChipDrawable.createFromAttributes(requireContext(), null, 0, chipStyles.random())
                 Chip(requireContext()).apply {
                     text = recommend[i]
                     setTextColor(Color.WHITE)

--- a/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchTagAdapter.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchTagAdapter.kt
@@ -1,4 +1,4 @@
-package com.cocaine.myply.feature.ui.keep
+package com.cocaine.myply.feature.ui.search
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.cocaine.myply.R
 import com.cocaine.myply.databinding.ItemMypageKeywordBinding
 
-class KeepDetailAdapter: ListAdapter<String, KeepDetailAdapter.KeepDetailViewHolder>(diffUtil) {
+class SearchTagAdapter: ListAdapter<String, SearchTagAdapter.KeepDetailViewHolder>(diffUtil) {
     companion object {
         val diffUtil = object : DiffUtil.ItemCallback<String>() {
             override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
@@ -25,8 +25,14 @@ class KeepDetailAdapter: ListAdapter<String, KeepDetailAdapter.KeepDetailViewHol
 
     class KeepDetailViewHolder(private val binding: ItemMypageKeywordBinding): RecyclerView.ViewHolder(binding.root) {
         fun bind(tag: String) {
+            val colors = listOf(
+                R.color.secondary_red,
+                R.color.secondary_yellow,
+                R.color.primary_green_light,
+                R.color.secondary_blue
+            )
             binding.keyword = tag
-            binding.keywordView.setBackgroundColor(binding.root.resources.getColor(R.color.secondary_brown, null))
+            binding.keywordView.setBackgroundColor(binding.root.resources.getColor(colors.random(), null))
         }
     }
 

--- a/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchUsecase.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchUsecase.kt
@@ -7,4 +7,6 @@ class SearchUsecase @Inject constructor(private val myPlyRemoteRepository: MyPly
     suspend fun getRecommendKeyworkd() = myPlyRemoteRepository.getRecommendKeyword()
 
     suspend fun searchMusicPlayList(query: String, nextPageToken: String? = null) = myPlyRemoteRepository.searchMusicPlayList(query, nextPageToken)
+
+    suspend fun addMemo(youtubeId: String, body: String = "") = myPlyRemoteRepository.addMemo(youtubeId, body)
 }

--- a/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/cocaine/myply/feature/ui/search/SearchViewModel.kt
@@ -43,4 +43,10 @@ class SearchViewModel @Inject constructor(private val usecase: SearchUsecase) : 
             }
         }
     }
+
+    fun addMemo(youtubeId: String) {
+        viewModelScope.launch(Dispatchers.IO + coroutineExceptionHandler) {
+            usecase.addMemo(youtubeId)
+        }
+    }
 }

--- a/app/src/main/res/drawable/dialog_negative_btn.xml
+++ b/app/src/main/res/drawable/dialog_negative_btn.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white" />
+            <stroke android:color="@color/gray_40" android:width="1dp"/>
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/dialog_positive_btn.xml
+++ b/app/src/main/res/drawable/dialog_positive_btn.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/primary_green_basic" />
+            <stroke android:color="@color/primary_green_basic" android:width="1dp"/>
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/dialog_two_button.xml
+++ b/app/src/main/res/layout/dialog_two_button.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/beige"
+        android:minWidth="295dp"
+        android:minHeight="158dp">
+
+        <TextView
+            android:id="@+id/dialog_title"
+            style="@style/Body1_Bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:textColor="@color/gray_90"
+            android:textSize="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:background="@android:color/transparent"
+            tools:text="title" />
+
+        <TextView
+            android:id="@+id/dialog_subtitle"
+            style="@style/Body2_Semibold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/gray_60"
+            android:textSize="14dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/dialog_title"
+            tools:background="@android:color/transparent"
+            tools:text="subtitle" />
+
+        <Button
+            android:id="@+id/dialog_negative"
+            android:layout_width="wrap_content"
+            android:layout_height="44dp"
+            android:background="@drawable/dialog_negative_btn"
+            android:minWidth="120dp"
+            android:textColor="@color/gray_70"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/dialog_positive"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/dialog_subtitle"
+            tools:text="취소" />
+
+        <Button
+            android:id="@+id/dialog_positive"
+            android:layout_width="wrap_content"
+            android:layout_height="44dp"
+            android:background="@drawable/dialog_positive_btn"
+            android:minWidth="120dp"
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/dialog_negative"
+            app:layout_constraintTop_toBottomOf="@id/dialog_subtitle"
+            tools:text="삭제" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_keep_detail.xml
+++ b/app/src/main/res/layout/fragment_keep_detail.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
         <variable
             name="viewModel"
             type="com.cocaine.myply.feature.ui.keep.KeepDetailViewModel" />
@@ -66,7 +65,8 @@
                 android:minHeight="284dp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/keep_detail_appbar"
-                app:memo="@{viewModel.memoDetail}" />
+                app:memo="@{viewModel.memoDetail}"
+                app:listener="@{view}"/>
 
             <EditText
                 android:id="@+id/keep_detail_memo"

--- a/app/src/main/res/layout/item_keep.xml
+++ b/app/src/main/res/layout/item_keep.xml
@@ -13,9 +13,9 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:minHeight="180dp"
         android:layout_marginBottom="16dp"
-        android:background="@color/white">
+        android:background="@color/white"
+        android:minHeight="180dp">
 
         <ImageView
             android:id="@+id/keep_img"
@@ -33,12 +33,12 @@
             android:id="@+id/keep_like"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_like_active"
-            android:background="@android:color/transparent"
-            android:layout_marginTop="12dp"
             android:layout_marginStart="12dp"
-            app:layout_constraintTop_toTopOf="@id/keep_img"
-            app:layout_constraintStart_toStartOf="@id/keep_img"/>
+            android:layout_marginTop="12dp"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_like_active"
+            app:layout_constraintStart_toStartOf="@id/keep_img"
+            app:layout_constraintTop_toTopOf="@id/keep_img" />
 
         <TextView
             android:id="@+id/keep_title"
@@ -46,29 +46,30 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
             android:layout_marginEnd="15dp"
+            android:background="@android:color/transparent"
             android:ellipsize="end"
             android:maxLines="2"
             android:text="@{memo.title}"
             android:textColor="@color/black"
-            android:background="@android:color/transparent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/keep_img"
             app:layout_constraintTop_toTopOf="@id/keep_img"
             tools:text="song title\n111" />
 
-        <com.google.android.material.chip.ChipGroup
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/keep_tags"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
             android:orientation="horizontal"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="@id/keep_guideline"
+            app:layout_constraintEnd_toEndOf="@id/keep_guideline"
             app:layout_constraintStart_toStartOf="@id/keep_title"
             app:layout_constraintTop_toBottomOf="@id/keep_title"
-            app:layout_constraintBottom_toBottomOf="@id/keep_img"
-            app:layout_constraintEnd_toEndOf="@id/keep_title"
-            app:singleLine="true"
-            tools:itemCount="5" />
+            tools:itemCount="3"
+            tools:listitem="@layout/item_mypage_keyword">
+
+        </androidx.recyclerview.widget.RecyclerView>
 
         <View
             android:id="@+id/keep_guideline"

--- a/app/src/main/res/layout/item_keep_detail.xml
+++ b/app/src/main/res/layout/item_keep_detail.xml
@@ -4,19 +4,25 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="memo"
             type="com.cocaine.myply.feature.data.model.MemoInfo" />
+
         <import type="com.cocaine.myply.feature.data.model.MemoState" />
+
+        <variable
+            name="listener"
+            type="com.cocaine.myply.feature.ui.keep.KeepDetailFragment" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:minHeight="285dp"
         android:layout_marginBottom="16dp"
         android:background="@color/white"
         android:elevation="5dp"
+        android:minHeight="285dp"
         android:padding="16dp">
 
         <ImageView
@@ -51,21 +57,24 @@
             app:layout_constraintTop_toBottomOf="@id/playlist_thumbnail"
             tools:text="[Playlist] 백예린의 수족관" />
 
-        <com.google.android.material.chip.ChipGroup
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/playlist_tags"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            app:layoutManager="com.google.android.flexbox.FlexboxLayoutManager"
             app:layout_constraintEnd_toStartOf="@id/playlist_heart"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/playlist_heart"
-            tools:itemCount="4" />
+            tools:itemCount="4"
+            tools:listitem="@layout/item_mypage_keyword" />
 
         <ImageView
             android:id="@+id/playlist_heart"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
+            android:onClick="@{() -> listener.deleteMemo()}"
             android:src="@drawable/ic_like_active"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_chainStyle="spread_inside"

--- a/app/src/main/res/layout/item_playlist.xml
+++ b/app/src/main/res/layout/item_playlist.xml
@@ -29,6 +29,7 @@
             tools:background="@color/gray_40" />
 
         <ImageView
+            android:id="@+id/playlist_play_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
@@ -48,31 +49,40 @@
             android:text="@{video.title}"
             android:textColor="@color/gray_80"
             app:layout_constraintTop_toBottomOf="@id/playlist_thumbnail"
-            tools:text="[Playlist] 백예린의 수족관" />
+            tools:text="[Playlist] 백예린의 수족관"
+            tools:background="@android:color/transparent"/>
 
-        <com.google.android.material.chip.ChipGroup
-            android:id="@+id/playlist_tags"
+        <HorizontalScrollView
+            android:id="@+id/playlist_tags_scroll"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toStartOf="@id/playlist_heart"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/playlist_heart"
-            app:singleLine="true"
-            tools:itemCount="4" />
+            app:layout_constraintBottom_toBottomOf="@id/playlist_heart"
+            tools:background="@android:color/transparent">
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/playlist_tags"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:singleLine="true"
+                tools:itemCount="4" />
+        </HorizontalScrollView>
 
         <ImageView
             android:id="@+id/playlist_heart"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
-            android:src="@{video.memoState == MemoState.FILLED ? @drawable/ic_like_active : @drawable/ic_like_inactive}"
+            android:src="@{video.memoState == MemoState.EMPTY ? @drawable/ic_like_inactive : @drawable/ic_like_active}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
-            app:layout_constraintStart_toEndOf="@id/playlist_tags"
+            app:layout_constraintStart_toEndOf="@id/playlist_tags_scroll"
             app:layout_constraintTop_toBottomOf="@id/playlist_title" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_playlist.xml
+++ b/app/src/main/res/layout/item_playlist.xml
@@ -52,26 +52,18 @@
             tools:text="[Playlist] 백예린의 수족관"
             tools:background="@android:color/transparent"/>
 
-        <HorizontalScrollView
-            android:id="@+id/playlist_tags_scroll"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/playlist_tags"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            android:orientation="horizontal"
             app:layout_constraintEnd_toStartOf="@id/playlist_heart"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/playlist_heart"
             app:layout_constraintBottom_toBottomOf="@id/playlist_heart"
-            tools:background="@android:color/transparent">
-
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/playlist_tags"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:singleLine="true"
-                tools:itemCount="4" />
-        </HorizontalScrollView>
+            tools:background="@android:color/transparent"/>
 
         <ImageView
             android:id="@+id/playlist_heart"
@@ -82,7 +74,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
-            app:layout_constraintStart_toEndOf="@id/playlist_tags_scroll"
+            app:layout_constraintStart_toEndOf="@id/playlist_tags"
             app:layout_constraintTop_toBottomOf="@id/playlist_title" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -56,6 +56,9 @@
         <action
             android:id="@+id/action_keepDetailFragment_to_keepShareFragment"
             app:destination="@id/keepShareFragment" />
+        <action
+            android:id="@+id/action_keepDetailFragment_to_myPlyTwoButtonDialog"
+            app:destination="@id/myPlyTwoButtonDialog" />
     </fragment>
     <fragment
         android:id="@+id/keepWriteFragment"
@@ -69,4 +72,8 @@
         android:id="@+id/onBoardingFragment"
         android:name="com.cocaine.myply.feature.ui.onboarding.OnBoardingFragment"
         android:label="OnBoardingFragment" />
+    <dialog
+        android:id="@+id/myPlyTwoButtonDialog"
+        android:name="com.cocaine.myply.feature.ui.dialog.MyPlyTwoButtonDialog"
+        android:label="MyPlyTwoButtonDialog" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,11 @@
     <string name="keep_write_memo_title">나의 감상 기록</string>
     <string name="keep_write_hint">플레이리스트에 대한 나의 감상을 기록해 보세요.</string>
     <string name="keep_write_count">%d/200</string>
+    <string name="keep_delete_title">플레이리스트를 보관함에서 삭제할까요?</string>
+    <string name="keep_delete_body">작성된 감상 기록이 함께 삭제됩니다.</string>
+    <string name="keep_delete_pos">삭제</string>
+    <string name="keep_delete_neg">취소</string>
+
 
     <string name="mypage">마이페이지</string>
     <string name="mypage_keyword">%s의 취향 키워드</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -132,4 +132,38 @@
         <item name="cornerSize">24dp</item>
     </style>
 
+    <style name="MyPly.Chip" parent="Widget.Material3.Chip.Suggestion">
+        <item name="chipCornerRadius">0dp</item>
+        <item name="android:textAppearance">@style/Body2_Bold</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="ensureMinTouchTargetSize">false</item>
+        <item name="android:includeFontPadding">true</item>
+    </style>
+
+    <!-- Keep Cheep Style -->
+    <style name="MyPly.Chip.Keep" parent="MyPly.Chip">
+        <item name="chipBackgroundColor">@color/secondary_brown</item>
+        <item name="chipStrokeColor">@color/secondary_brown</item>
+    </style>
+
+    <style name="MyPly.Chip.Red" parent="MyPly.Chip">
+        <item name="chipBackgroundColor">@color/secondary_red</item>
+        <item name="chipStrokeColor">@color/secondary_red</item>
+    </style>
+
+    <style name="MyPly.Chip.Blue" parent="MyPly.Chip">
+        <item name="chipBackgroundColor">@color/secondary_blue</item>
+        <item name="chipStrokeColor">@color/secondary_blue</item>
+    </style>
+
+    <style name="MyPly.Chip.yellow" parent="MyPly.Chip">
+        <item name="chipBackgroundColor">@color/secondary_yellow</item>
+        <item name="chipStrokeColor">@color/secondary_yellow</item>
+    </style>
+
+    <style name="MyPly.Chip.green" parent="MyPly.Chip">
+        <item name="chipBackgroundColor">@color/primary_green_light</item>
+        <item name="chipStrokeColor">@color/primary_green_light</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## 완료 작업
- 검색 화면 상에서 키보드 엔터로 검색되게 추가
- 하트 버튼 클릭 시, 보관함에 추가
- 재생 버튼 클릭 시, 유튜브 재생
- 검색 화면 칩그룹 -> RecyclerView 변경
- 보관함 삭제를 위한 다이얼로그 추가